### PR TITLE
fix: staff 확인시 pk값만 반환

### DIFF
--- a/community/serializers.py
+++ b/community/serializers.py
@@ -111,8 +111,8 @@ class PostSerializer(serializers.ModelSerializer):
         return obj.comment_set.count()
 
     def get_staffs(self, obj):
-        staffs = obj.board.staffs.all()
-        return UserSerializer(staffs, many=True).data
+        staffs = obj.board.staffs.values_list('pk', flat=True)
+        return list(staffs)
 
 
 class CommentNotGetSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
{
            "id": 10,
            "user": {
                "pk": 4,
                "email": "user2@user.com",
                "nickname": "user2",
                "is_writer": true,
                "is_active": true
            },
            "board": "@test",
           ....
            "staffs": [
                3
            ],
        },
        
이렇게 staffs는 pk의 리스트를 반환합니다.